### PR TITLE
Improve `git-open` function

### DIFF
--- a/.bashrc.d/functions
+++ b/.bashrc.d/functions
@@ -94,7 +94,7 @@ function git-config-opensource {
 }
 
 function git-open {
-  open $(git remote -v | awk '/fetch/{print $2}' | sed -Ee 's#(git@|git://)#http://#' -e 's@com:@com/@') | head -n1
+  open $(git remote -v | grep -v heroku | awk '/fetch/{print $2}' | sed -Ee 's#(git@|git://)#http://#' -e 's@com:@com/@') | head -n1
 }
 
 function kube_ctx {


### PR DESCRIPTION
This change improves the `git-open` function, making it disregard heroku
remotes, when they exist in the local repository clone.